### PR TITLE
Spring Boot 3

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -73,6 +73,11 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -182,6 +187,7 @@
 								<interfaceOnly>true</interfaceOnly>
 								<performBeanValidation>true</performBeanValidation>
 								<library>spring-cloud</library>
+								<useSpringBoot3>true</useSpringBoot3>
 							</configOptions>
 							<output>${project.build.directory}/generated-sources/openapi/main</output>
 							<generateApiDocumentation>false</generateApiDocumentation>

--- a/documentation/src/main/resources/helloservice.yaml
+++ b/documentation/src/main/resources/helloservice.yaml
@@ -83,3 +83,4 @@ components:
           description: Your name
           type: string
           example: "John Doe"
+          maxLength: 8

--- a/integrationtest/src/test/java/dk/kvalitetsit/hello/integrationtest/HelloIT.java
+++ b/integrationtest/src/test/java/dk/kvalitetsit/hello/integrationtest/HelloIT.java
@@ -1,5 +1,6 @@
 package dk.kvalitetsit.hello.integrationtest;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -30,5 +31,14 @@ public class HelloIT extends AbstractIntegrationTest {
         assertEquals(input.getName(), result.getName());
         assertNull(result.getiCanBeNull());
         assertNotNull(result.getNow());
+    }
+
+    @Test
+    public void testCallServiceNameTooLong() throws ApiException {
+        var input = new HelloRequest();
+        input.setName("John Doe Is Too Long");
+
+        var thrownException = Assert.assertThrows(ApiException.class, () -> helloApi.v1HelloPost(input));
+        assertEquals(400, thrownException.getCode());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,14 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<!-- Servlet API -->
+			<dependency>
+				<groupId>javax.servlet</groupId>
+				<artifactId>javax.servlet-api</artifactId>
+				<scope>provided</scope>
+				<version>3.1.0</version>
+			</dependency>
+
 			<!-- Logging -->
 			<dependency>
 				<groupId>net.logstash.logback</groupId>
@@ -180,6 +188,13 @@
 				<groupId>io.gsonfire</groupId>
 				<artifactId>gson-fire</artifactId>
 				<version>1.8.5</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>javax.annotation</groupId>
+				<artifactId>javax.annotation-api</artifactId>
+				<version>1.3.2</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -80,14 +80,6 @@
 				<version>${project.version}</version>
 			</dependency>
 
-			<!-- Servlet API -->
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<scope>provided</scope>
-				<version>3.1.0</version>
-			</dependency>
-
 			<!-- Logging -->
 			<dependency>
 				<groupId>net.logstash.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.5</version>
+		<version>3.0.0</version>
 	</parent>
 	<groupId>dk.kvalitetsit.kithugs</groupId>
 	<artifactId>kithugs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 	<properties>
 		<java.version>17</java.version>
 		<testcontainers.version>1.17.6</testcontainers.version>
-		<spring-prometheus-app-info-version>1.2.0</spring-prometheus-app-info-version>
-		<spring-request-id-logger-version>1.2.1</spring-request-id-logger-version>
+		<spring-prometheus-app-info-version>2.0.0</spring-prometheus-app-info-version>
+		<spring-request-id-logger-version>2.0.0</spring-request-id-logger-version>
 		<jacoco-version>0.8.8</jacoco-version>
 	</properties>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -69,8 +69,8 @@
 
         <!-- Servlet API -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
- Bump spring-boot-starter-parent from 2.7.5 to 3.0.0
- Spring Boot 3 migration.
- Use Jakarta Servlet API.
- Bump prometheus info and request id logger to Spring Boot 3 supported versions.
