### PR TITLE
Minor updates

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -27,13 +27,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.swagger</groupId>
-			<artifactId>swagger-annotations</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.ws.rs</groupId>
-			<artifactId>javax.ws.rs-api</artifactId>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
 		</dependency>
 
 		<dependency>
@@ -42,12 +37,6 @@
 		</dependency>
 
 		<!-- Test dependencies -->
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
@@ -70,12 +59,6 @@
 		<dependency>
 			<groupId>io.gsonfire</groupId>
 			<artifactId>gson-fire</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -165,6 +148,8 @@
 							<configOptions>
 								<sourceFolder>src/test/java</sourceFolder>
 								<dateLibrary>java8</dateLibrary>
+								<useSpringBoot3>true</useSpringBoot3>
+								<useJakartaEe>true</useJakartaEe>
 							</configOptions>
 							<output>${project.build.directory}/generated-test-sources/openapi/test</output>
 							<generateApiTests>false</generateApiTests>
@@ -188,6 +173,7 @@
 								<performBeanValidation>true</performBeanValidation>
 								<library>spring-cloud</library>
 								<useSpringBoot3>true</useSpringBoot3>
+								<useJakartaEe>true</useJakartaEe>
 								<useTags>true</useTags>
 							</configOptions>
 							<output>${project.build.directory}/generated-sources/openapi/main</output>

--- a/documentation/src/main/resources/api.yaml
+++ b/documentation/src/main/resources/api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: Kithugs
   description: API description for KITHUGS.

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -24,12 +24,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Jacoco agent to include in test docker image must not be in scope test even if only used by test. -->
         <dependency>
             <groupId>org.jacoco</groupId>
@@ -95,12 +89,6 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
             <version>4.12.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/integrationtest/src/test/resources/logback-test.xml
+++ b/integrationtest/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - correlation-id: %X{correlation-id} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %mdc - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,43 +92,33 @@
 				<version>2.2.27</version>
 			</dependency>
 
-			<dependency>
-				<groupId>io.swagger</groupId>
-				<artifactId>swagger-annotations</artifactId>
-				<version>1.6.14</version>
-			</dependency>
-
-			<!-- javax ws rs -->
-			<dependency>
-				<groupId>javax.ws.rs</groupId>
-				<artifactId>javax.ws.rs-api</artifactId>
-				<version>2.1.1</version>
-			</dependency>
-
-
 			<!-- Test dependencies - test containers -->
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>mockserver</artifactId>
 				<version>${testcontainers.version}</version>
+				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.testcontainers</groupId>
 				<artifactId>mariadb</artifactId>
 				<version>${testcontainers.version}</version>
+				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.mock-server</groupId>
 				<artifactId>mockserver</artifactId>
 				<version>3.12</version>
+				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>org.mock-server</groupId>
 				<artifactId>mockserver-client-java</artifactId>
 				<version>5.15.0</version>
+				<scope>test</scope>
 			</dependency>
 
 			<!-- Code coverage -->
@@ -140,10 +130,10 @@
 
 			<!-- Integration test client dependencies -->
 			<dependency>
-				<groupId>com.google.code.findbugs</groupId>
-				<artifactId>jsr305</artifactId>
-				<version>3.0.2</version>
-				<scope>test</scope>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs</artifactId>
+				<version>4.8.6</version>
+				<type>pom</type>
 			</dependency>
 
 			<dependency>
@@ -157,13 +147,6 @@
 				<groupId>io.gsonfire</groupId>
 				<artifactId>gson-fire</artifactId>
 				<version>1.9.0</version>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>javax.annotation</groupId>
-				<artifactId>javax.annotation-api</artifactId>
-				<version>1.3.2</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>
@@ -262,6 +245,11 @@
 					<outputFormat>all</outputFormat>
 					<outputName>service-sbom</outputName>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>4.8.6.4</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/service/src/main/java/dk/kvalitetsit/hello/controller/ErrorController.java
+++ b/service/src/main/java/dk/kvalitetsit/hello/controller/ErrorController.java
@@ -21,7 +21,7 @@ public class ErrorController {
 
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<DetailedError> handleApiException(ValidationException e, HttpServletRequest request) {
-        logger.debug("Handling ValidationException.");
+        logger.debug("Handling ValidationException.", e);
 
         var error = getDetailedBadRequestErrorMessage(request, e.getMessage());
         return ResponseEntity.badRequest().body(error);
@@ -29,7 +29,7 @@ public class ErrorController {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<DetailedError> meth(MethodArgumentNotValidException e, HttpServletRequest request) {
-        logger.debug("Handling MethodArgumentNotValidException.");
+        logger.debug("Handling MethodArgumentNotValidException.", e);
 
         var error = getDetailedBadRequestErrorMessage(request, validationErrorToString(e));
         return ResponseEntity.badRequest().body(error);
@@ -37,7 +37,7 @@ public class ErrorController {
 
     @ExceptionHandler(AbstractApiException.class)
     public ResponseEntity<DetailedError> handleApiException(AbstractApiException e, HttpServletRequest request) {
-        logger.debug("Handling ApiException: {}", e.getHttpStatus());
+        logger.debug("Handling ApiException: {}", e.getHttpStatus(), e);
         var error = new DetailedError()
                 .path(request.getRequestURI())
                 .timestamp(OffsetDateTime.now())

--- a/web/docker/config/logback.xml
+++ b/web/docker/config/logback.xml
@@ -9,7 +9,7 @@
                         {
                         "logger": "%logger",
                         "level": "%level",
-                        "correlation-id": "%X{correlation-id}",
+                        "mdc": "%mdc",
                         "thread": "%thread",
                         "message": "%m"
                         }

--- a/web/docker/entrypoint.sh
+++ b/web/docker/entrypoint.sh
@@ -21,7 +21,7 @@ if [[ -z $LOG_LEVEL_FRAMEWORK ]]; then
 fi
 
 if [[ -z $CORRELATION_ID ]]; then
-  echo "Default CORRELATION_ID = correlation-id"
+  echo "Default CORRELATION_ID = x-request-id"
   export CORRELATION_ID=x-request-id
 fi
 


### PR DESCRIPTION
Nogle små ændringer jeg har tænkt på mens jeg har kigget det igennem til færdselsstyrelsen projekt: 
- swagger/swagger3/javax/jakarta delen er så vi kun bruger swagger 3 og jakarta. Det nuværende er lidt et miks af alt
- mockserver-client-java er fjernet fjernet fordi det ikke bliver brugt og ikke bliver maintained. Hvis noget skal med i den stil kan jeg tilføje https://github.com/wiremock/wiremock som virker godt
- jsr305 bliver heller ikke maintained længere, erstattet af spotbugs-maven-plugin. Det er nu et maven plugin så man kan køre `mvn spotbugs:check` på alle projekter
- request-id/correlation-id loggede den forkerte default værdi (ved opstart), og så har jeg bare tilføjet den smider alt fra mdc'en ind i loggen, i stedet for kun den ene værdi (selvom der kun er en værdi lige pt)