### PR TITLE
chore: add `cooldown` to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,9 +5,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Wait 14 days before updating to help circumvent supply chain attacks
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Wait 14 days before updating to help circumvent supply chain attacks
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
This PR will add a cooldown for 14 days to dependabot, to circumvent supply chain attacks.